### PR TITLE
Add: Window mode for persistent dashboard display

### DIFF
--- a/Sources/MacNTop/MenuBar/StatusBarController.swift
+++ b/Sources/MacNTop/MenuBar/StatusBarController.swift
@@ -10,15 +10,16 @@ public final class StatusBarController {
     private let iconRenderer = StatusBarIconRenderer()
 
     private var dashboardViewController: DashboardViewController?
+    private var dashboardWindow: DashboardWindow?
     private var eventMonitor: Any?
 
     // MARK: - Initialization
 
     public init() {
-        observeThemeChanges()
+        observeNotifications()
     }
 
-    private func observeThemeChanges() {
+    private func observeNotifications() {
         NotificationCenter.default.addObserver(
             forName: .themeChanged,
             object: nil,
@@ -26,6 +27,16 @@ public final class StatusBarController {
         ) { [weak self] _ in
             Task { @MainActor in
                 self?.recreatePopover()
+            }
+        }
+
+        NotificationCenter.default.addObserver(
+            forName: .dashboardWindowClosed,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.dashboardWindow = nil
             }
         }
     }
@@ -77,6 +88,27 @@ public final class StatusBarController {
     /// Updates the dashboard with new metrics.
     public func updateDashboard(with snapshot: MetricsSnapshot, systemInfo: SystemInfo) {
         dashboardViewController?.updateMetrics(snapshot: snapshot, systemInfo: systemInfo)
+        dashboardWindow?.updateMetrics(snapshot: snapshot, systemInfo: systemInfo)
+    }
+
+    /// Opens the dashboard in a standalone window.
+    public func openWindow() {
+        if dashboardWindow == nil {
+            dashboardWindow = DashboardWindow()
+        }
+        dashboardWindow?.showWindow()
+        hidePopover()
+    }
+
+    /// Closes the dashboard window.
+    public func closeWindow() {
+        dashboardWindow?.close()
+        dashboardWindow = nil
+    }
+
+    /// Returns whether the dashboard window is currently open.
+    public var isWindowOpen: Bool {
+        dashboardWindow?.isVisible == true
     }
 
     /// Shows the popover.
@@ -100,6 +132,8 @@ public final class StatusBarController {
             NSEvent.removeMonitor(monitor)
             eventMonitor = nil
         }
+        dashboardWindow?.close()
+        dashboardWindow = nil
         statusItem = nil
         popover = nil
     }
@@ -142,6 +176,15 @@ public final class StatusBarController {
     private func showContextMenu(from button: NSStatusBarButton) {
         let menu = NSMenu()
 
+        // Window mode toggle
+        if isWindowOpen {
+            menu.addItem(NSMenuItem(title: "Close Window", action: #selector(toggleWindowMode), keyEquivalent: "w"))
+        } else {
+            menu.addItem(NSMenuItem(title: "Open in Window", action: #selector(toggleWindowMode), keyEquivalent: "w"))
+        }
+
+        menu.addItem(NSMenuItem.separator())
+
         // Theme submenu
         let themeMenu = NSMenu()
         let currentTheme = AppTheme.current
@@ -176,6 +219,15 @@ public final class StatusBarController {
     private func selectTheme(_ sender: NSMenuItem) {
         guard let theme = sender.representedObject as? ThemeColors else { return }
         AppTheme.setTheme(theme)
+    }
+
+    @objc
+    private func toggleWindowMode() {
+        if isWindowOpen {
+            closeWindow()
+        } else {
+            openWindow()
+        }
     }
 
     @objc

--- a/Sources/MacNTop/Views/DashboardWindow.swift
+++ b/Sources/MacNTop/Views/DashboardWindow.swift
@@ -1,0 +1,102 @@
+import AppKit
+
+/// A standalone window for displaying the dashboard.
+@MainActor
+public final class DashboardWindow: NSWindow {
+    // MARK: - Properties
+
+    private let dashboardViewController: DashboardViewController
+
+    // MARK: - Initialization
+
+    public init() {
+        self.dashboardViewController = DashboardViewController()
+
+        let contentRect = NSRect(x: 0, y: 0, width: 480, height: 720)
+        super.init(
+            contentRect: contentRect,
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+
+        setupWindow()
+    }
+
+    // MARK: - Setup
+
+    private func setupWindow() {
+        title = "MacNTop"
+        contentViewController = dashboardViewController
+        minSize = NSSize(width: 400, height: 600)
+        maxSize = NSSize(width: 600, height: 900)
+
+        // Set appearance
+        backgroundColor = RetroTheme.background
+        isOpaque = false
+        hasShadow = true
+
+        // Float above other windows but not annoyingly so
+        level = .floating
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        // Position near top-right of screen
+        if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let windowFrame = frame
+            let x = screenFrame.maxX - windowFrame.width - 20
+            let y = screenFrame.maxY - windowFrame.height - 20
+            setFrameOrigin(NSPoint(x: x, y: y))
+        }
+
+        // Observe theme changes
+        NotificationCenter.default.addObserver(
+            forName: .themeChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateAppearance()
+            }
+        }
+    }
+
+    private func updateAppearance() {
+        backgroundColor = RetroTheme.background
+    }
+
+    // MARK: - Public Methods
+
+    /// Updates the dashboard with new metrics.
+    public func updateMetrics(snapshot: MetricsSnapshot, systemInfo: SystemInfo) {
+        dashboardViewController.updateMetrics(snapshot: snapshot, systemInfo: systemInfo)
+    }
+
+    /// Shows the window and brings it to front.
+    public func showWindow() {
+        makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    // MARK: - NSWindow Overrides
+
+    public override var canBecomeKey: Bool {
+        true
+    }
+
+    public override var canBecomeMain: Bool {
+        true
+    }
+
+    public override func close() {
+        // Post notification so StatusBarController knows window closed
+        NotificationCenter.default.post(name: .dashboardWindowClosed, object: self)
+        super.close()
+    }
+}
+
+// MARK: - Notification Extension
+
+extension Notification.Name {
+    static let dashboardWindowClosed = Notification.Name("DashboardWindowClosed")
+}


### PR DESCRIPTION
## Summary

- Add standalone floating window mode for the dashboard
- Users can right-click and select "Open in Window" to detach the dashboard
- Window stays on top (floating level) and can join all spaces
- Window receives live metric updates just like the popover
- "Close Window" option appears when window is open

## Features

- **DashboardWindow**: New `NSWindow` subclass with:
  - Floating window level (stays above other windows)
  - Joins all spaces for multi-desktop support
  - Proper sizing constraints (min: 400x600, max: 600x900)
  - Auto-positions near top-right of screen
  - Theme change support
  - Clean close notification handling

- **StatusBarController updates**:
  - New `openWindow()` / `closeWindow()` public methods
  - `isWindowOpen` property for state checking
  - Context menu toggle between "Open in Window" and "Close Window"
  - Both popover and window receive metric updates
  - Proper cleanup on app termination

## Test plan

- [x] Build succeeds
- [x] All 14 unit tests pass
- [ ] Right-click menu shows "Open in Window"
- [ ] Clicking opens floating window with dashboard
- [ ] Window receives live metric updates
- [ ] Menu changes to "Close Window" when open
- [ ] Window closes properly and menu resets
- [ ] Theme changes apply to window
- [ ] Window survives space changes

---

🤖 Generated with [Claude Code](https://claude.ai/code)