### PR TITLE
CI: standardize Actions (paths + concurrency + runners)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/ci.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/ci.yml
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build and Test (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+      - name: Build
+        run: swift build
+      - name: Test
+        run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ on:
       - Package.resolved
       - .github/workflows/ci.yml
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Adds CI to this public Swift package, which previously had zero build/test automation on push or PR.

Changes (all under .github/workflows/):
- New .github/workflows/ci.yml running `swift build` + `swift test`.
- Runner: `macos-latest` (GitHub-hosted). PUBLIC repo, so no self-hosted runners. The package is macOS-only (`platforms: [.macOS(.v14)]`, links AppKit/IOKit/Metal), so no Linux job is included.
- `paths:` filter on push/pull_request scoped to Swift sources: `Sources/**`, `Tests/**`, `Package.swift`, `Package.resolved`, plus `.github/workflows/ci.yml` — README/docs/LICENSE-only changes trigger nothing.
- `concurrency:` group `ci-${{ github.ref }}` with `cancel-in-progress: true`.
- `actions/checkout@v5`, `timeout-minutes: 30`.

No fledge.toml present, so native swift commands are used. Mirrors the CorvidLabs/merlin CI standard.