### PR TITLE
Add magpie dogfood: build, launch, screenshot, teardown

### DIFF
--- a/.github/workflows/magpie-dogfood.yml
+++ b/.github/workflows/magpie-dogfood.yml
@@ -1,0 +1,16 @@
+name: magpie dogfood
+
+# Manual trigger only for this first pass — not wired to push/pull_request
+# yet, so it can't become a blocking check before it's actually proven
+# reliable against a real build of this app. Promote it once it's green a
+# few times in a row.
+on:
+  workflow_dispatch:
+
+jobs:
+  dogfood:
+    uses: CorvidLabs/magpie/.github/workflows/test.yml@main
+    with:
+      specs-dir: .magpie/specs
+      linux-targets: none
+      macos-targets: macos

--- a/.magpie/scripts/launch.sh
+++ b/.magpie/scripts/launch.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Builds MacNTop and launches it detached in the background, then asserts
+# it's still alive a couple of seconds later. `kill -0` on a dead PID exits
+# non-zero, and with `set -e` that fails this step honestly — a real crash-
+# on-launch regression, not a harness quirk.
+set -e
+swift build
+nohup .build/debug/MacNTop >/tmp/macntop.log 2>&1 &
+echo $! > /tmp/macntop.pid
+sleep 2
+kill -0 "$(cat /tmp/macntop.pid)"
+echo "MacNTop launched, pid $(cat /tmp/macntop.pid), still alive after 2s"

--- a/.magpie/scripts/teardown.sh
+++ b/.magpie/scripts/teardown.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Deliberately no `set -e`: teardown must succeed even if launch already
+# failed or the process already died, so a broken run still cleans up.
+if [ -f /tmp/macntop.pid ]; then
+	kill "$(cat /tmp/macntop.pid)" 2>/dev/null || true
+	rm -f /tmp/macntop.pid
+fi
+echo "teardown complete"

--- a/.magpie/specs/macos.3md
+++ b/.magpie/specs/macos.3md
@@ -1,0 +1,43 @@
+---
+3md: 1.0
+axis: skill
+agent: macntop-tester
+tools: sh, screencapture
+persona: builds MacNTop from source, launches it as a background process, and captures a real screenshot
+---
+Dogfoods CorvidLabs/magpie's macOS target against MacNTop itself. MacNTop
+is a menu-bar app (an SPM executable, not a windowed .app bundle), so this
+checks "does it build and launch without crashing" plus a screenshot,
+rather than the Accessibility-tree read magpie's own specs/macos.3md does
+for a normal-window app like Calculator.
+
+Every `tool=` below is a bare command (no `{placeholder}`) on purpose —
+magpie's generic --specs-dir engine only executes bare commands, since a
+shared engine can't guess fill values for someone else's project. See
+CorvidLabs/magpie's README, "Using this in another repo."
+
+@plane z=0 label="macntop-tester" kind=identity
+# macntop-tester
+
+Build, launch in the background, screenshot, then always tear down —
+regardless of what happened before — so no stray process survives a run.
+
+@plane z=1 label="launch" kind=skill triggers="build, launch, start" tool="sh .magpie/scripts/launch.sh" cost="build"
+# Skill: launch
+
+Builds this PR's MacNTop and launches it detached. Asserts the process is
+still alive a couple of seconds later — a fast crash-on-launch would
+already have exited by then.
+
+@plane z=2 label="screenshot" kind=skill triggers="screenshot, snapshot, capture" tool="screencapture -x artifacts/macos/screenshot.png" cost="fs"
+# Skill: screenshot
+
+Full-screen capture. MacNTop lives in the menu bar, so this is evidence it
+rendered, not a full UI read. Requires [[z=1|launch]].
+
+@plane z=3 label="teardown" kind=skill triggers="teardown, stop, cleanup, kill" tool="sh .magpie/scripts/teardown.sh"
+# Skill: teardown
+
+Kills the backgrounded process by its PID file. Always runs last (z-order),
+regardless of what launch/screenshot reported, so a failed run still
+cleans up. See [[z=1|launch]].


### PR DESCRIPTION
First pilot repo for [CorvidLabs/magpie](https://github.com/CorvidLabs/magpie)'s generic `--specs-dir` engine — a cross-platform, agent-driven testbed built this week. This is the first time it's pointed at a project other than itself.

## What this adds

- `.magpie/specs/macos.3md` — a small `agent.3md` spec (see magpie's README) with three skills: `launch` (build + detached launch, asserts still-alive after 2s), `screenshot` (full-screen capture — MacNTop lives in the menu bar, so this is evidence it rendered, not a UI read), `teardown` (always runs last, kills by PID file).
- `.magpie/scripts/{launch,teardown}.sh` — the glue those two skills shell out to.
- `.github/workflows/magpie-dogfood.yml` — calls magpie's reusable `workflow_call` workflow, `workflow_dispatch` only for now (not wired to push/PR yet, so it can't become a blocking check before it's proven reliable).

## Why `.magpie/specs/` and not `specs/`

This repo already has a `specs/` directory (Spec Sync's). Kept magpie's specs in a separate `.magpie/` directory on purpose to avoid any collision.

## Status

Every `tool=` command validates and renders correctly against the real `@corvidlabs/agent3md` parser (checked locally before this PR). The actual build+launch+screenshot+teardown sequence has **not** yet run on a live macOS runner — that's what triggering this workflow does. Expect to iterate once it has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)